### PR TITLE
fix(assets): added getAssetUrl for fetching an image/icon

### DIFF
--- a/src/features/Main/components/CardPartner/index.tsx
+++ b/src/features/Main/components/CardPartner/index.tsx
@@ -9,6 +9,7 @@ import {
 import { logoPartners } from '@/constants/images';
 import { FC } from 'react';
 import Image from 'next/image';
+import { getAssetUrl } from '@/lib/utils';
 
 const CardPartners: FC = () => {
   return (
@@ -26,7 +27,7 @@ const CardPartners: FC = () => {
           {logoPartners.map((item, index) => (
             <Image
               key={index}
-              src={`/../assets/img/${item.src}`}
+              src={`${getAssetUrl(`/img/${item.src}`)}`}
               alt={`${item.alt}`}
               width={200}
               height={300}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,5 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const getAssetUrl = (url: string) => `/assets${url}`;


### PR DESCRIPTION
## Ticket : ex: HMC-xx

## Description :

- added getAssetUrl for fetching an image/icon

## Screenshots / Video Record:
<img width="527" alt="Screenshot 2024-02-23 at 08 42 22" src="https://github.com/hammer-code/lms-fe/assets/76042524/6b8977e9-3a12-4d31-9452-2555d1827087">

## How to use:
1. Import the `getAssetUrl`  <br> <img width="420" alt="Screenshot 2024-02-23 at 08 43 13" src="https://github.com/hammer-code/lms-fe/assets/76042524/5d3f2c90-84cb-4c4c-a579-1b2b0abd1b72">
2. To retrieve image data like this, you can use the following approach: <br> <img width="491" alt="Screenshot 2024-02-23 at 08 44 36" src="https://github.com/hammer-code/lms-fe/assets/76042524/6d68a6df-968e-43f2-ad68-7c00251c5d10">

